### PR TITLE
Fix autocrop when used on a system with a German locale

### DIFF
--- a/filters/autocrop.cpp
+++ b/filters/autocrop.cpp
@@ -125,6 +125,12 @@ autocrop::arguments (const context& ctx)
   argv += (trim_ ? " trim" : " crop");
   argv += " " + lexical_cast< string > (ctx.octets_per_image ()
                                         + PNM_HEADER_SIZE);
+
+  // Resetting the locales may mess up the rest. For now, to fix the problem,
+  // just replace all commas with dots in case lexical_cast converts it wrong
+  // (e.g. with German locale)
+  std::replace(argv.begin(), argv.end(), ',', '.');
+
   argv += " -";
   argv += " pnm:-";
 


### PR DESCRIPTION
Hi. I'm using a system with a German locale. I noticed that autocrop fails. When turning on debugging logs, I get the following:

```
2018-Jan-28 14:41:35.787165[140414644016896]: /usr/libexec/utsushi/doc-locate started (pid: 10058)
2018-Jan-28 14:41:35.787304[140414644016896]: invocation: /usr/libexec/utsushi/doc-locate  0,60199999999999998 0,79299999999999993 crop 28404500 - pnm:-
2018-Jan-28 14:41:35.787584[140414644016896]: read JPEG header
2018-Jan-28 14:41:35.787893[140414644016896]: started JPEG decompression
2018-Jan-28 14:41:35.799882[140414644016896]: /usr/libexec/utsushi/doc-locate (pid: 10058): Invalid argument (0,60199999999999998)
2018-Jan-28 14:41:35.799964[140414644016896]: /usr/libexec/utsushi/doc-locate (pid: 10058): Broken pipe
2018-Jan-28 14:41:35.869351[140414644016896]: Corrupt JPEG data: 24 extraneous bytes after marker 0xd9
2018-Jan-28 14:41:35.869438[140414644016896]: /usr/libexec/utsushi/doc-locate exited (pid: 10058, status: 1)
2018-Jan-28 14:41:35.869474[140414644016896]: waitid (-1): Invalid argument
2018-Jan-28 14:41:35.869514[140414644016896]: Permission denied
2018-Jan-28 14:41:36.770711[140414652409600]: image acquisition terminated: ADF /PE 
```

Note that it inserts a comma instead of a dot as the decimal separator. 

## Fix

The attached patch fixes the problem by replacing it with a dot. I was thinking about using `std::setlocale` but didn't because I'm afraid of unwanted side-effects. My patch has been testing and it works (at least on my machine :) )

```
2018-Jan-28 15:11:04.665202[140565641651968]: invocation: /usr/libexec/utsushi/doc-locate  0.60199999999999998 0.79299999999999993 crop 28404500 - pnm:-
```

Qapla'!